### PR TITLE
Check if window exists before using it

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-pico-8-demo",
   "homepage": "http://woofers.github.io/react-pico-8",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "dependencies": {
     "@emotion/core": "^10.0.9",
     "@fortawesome/fontawesome-svg-core": "^1.2.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pico-8",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Run PICO-8 game cartridges in React",
   "main": "react-pico-8.js",
   "src": "src/pico-8.js",

--- a/src/event.js
+++ b/src/event.js
@@ -1,8 +1,12 @@
+import { hasWindow } from './window'
+
 export const addEvent = (name, func, options) => {
+  if (!hasWindow()) return
   window.addEventListener(name, func, options)
 }
 
 export const removeEvent = (name, func, options) => {
+  if (!hasWindow()) return
   window.removeEventListener(name, func, options)
 }
 

--- a/src/pico.js
+++ b/src/pico.js
@@ -1,3 +1,5 @@
+import { hasWindow } from './window'
+
 // The following code has been adapted to work with react-pico-8.
 // File generated from default PICO-8 web export.
 
@@ -52,6 +54,7 @@ const init = () => {
 const onTouch = (e) => window.p8_touch_detected = true
 
 export const startPico = () => {
+  if (!hasWindow()) return
   init()
   window.addEventListener("touchstart", onTouch, { passive: true })
   window.p8_create_audio_context = () => {
@@ -112,6 +115,7 @@ export const startPico = () => {
 }
 
 export const removePico = () => {
+  if (!hasWindow()) return
   window.removeEventListener("touchstart", onTouch, { passive: true })
   init()
 }

--- a/src/window.js
+++ b/src/window.js
@@ -1,0 +1,1 @@
+export const hasWindow = () => typeof window !== `undefined`


### PR DESCRIPTION
This resolves some issues in environments where `window` is not available