### PR TITLE
Prevent canvas from flickering when game is booted

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-pico-8-demo",
   "homepage": "http://woofers.github.io/react-pico-8",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "dependencies": {
     "@emotion/core": "^10.0.9",
     "@fortawesome/fontawesome-svg-core": "^1.2.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pico-8",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Run PICO-8 game cartridges in React",
   "main": "react-pico-8.js",
   "src": "src/pico-8.js",

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -12,6 +12,7 @@ const Canvas = p => {
     height: 85vmin;
     max-height: 768px;
     max-width: 768px;
+    background-color: #000;
   `
   const canvas = css`
     image-rendering: optimizeSpeed;


### PR DESCRIPTION
Prior to this commit, a delay appears between starting the game, which hides the
placeholder image, and the PICO-8 engine drawing the boot screen.

This results in a brief period where the canvas seems to disappear when the game starts.

This is resolved by adding a black background to the canvas so it remains visible.