### PR TITLE
Change default props to be more sensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run [PICO-8](https://lexaloffle.com/pico-8.php) game cartridges using a cusomtiz
 
 # Usage
 
-```js
+```jsx
 import React from 'react'
 import Pico8 from 'react-pico-8'
 import { Controls,
@@ -36,11 +36,11 @@ const App = () => (
   <Pico8 src="index.js"
          autoPlay={true}
          legacyButtons={false}
-         hideCursor={true}
+         hideCursor={false}
          center={true}
-         blockKeys={true}
+         blockKeys={false}
          usePointer={true}
-         unpauseOnReset={false}
+         unpauseOnReset={true}
          placeholder="placeholder.png"
   >
     <Controls/>
@@ -86,7 +86,7 @@ Since `react-pico-8` already has the game player embeded, only the `.js` file ne
 
 ### Hide Cursor
 
-`hideCusor` indicates if the cursor is hidden over the game canvas when the game is playing.  **Default:** `true`
+`hideCusor` indicates if the cursor is hidden over the game canvas when the game is playing.  **Default:** `false`
 
 
 ### Center
@@ -98,7 +98,7 @@ Since `react-pico-8` already has the game player embeded, only the `.js` file ne
 
 If `blockKeys` is set keys which are used to interact with the game are blocked from scrolling when the game is running.
 
-If un-set keys will only be blocked when the canvas is focused.  **Default:** `true`
+If un-set keys will only be blocked when the canvas is focused.  **Default:** `false`
 
 
 ### Use Pointer
@@ -112,7 +112,7 @@ If un-set a normal cursor will be used on all buttons which do not lead to a new
 
 If `unpauseOnReset` is set hitting the reset button when paused will instantly reset the game.
 
-If un-set the game will need to be resumed before it resets. **Default:** `false`
+If un-set the game will need to be resumed before it resets. **Default:** `true`
 
 
 ### Placeholder

--- a/README.org
+++ b/README.org
@@ -40,11 +40,11 @@ const App = () => (
   <Pico8 src="index.js"
          autoPlay={true}
          legacyButtons={false}
-         hideCursor={true}
+         hideCursor={false}
          center={true}
-         blockKeys={true}
+         blockKeys={false}
          usePointer={true}
-         unpauseOnReset={false}
+         unpauseOnReset={true}
          placeholder="placeholder.png"
   >
     <Controls/>
@@ -77,13 +77,13 @@ Since ~react-pico-8~ already has the game player embeded, only the ~.js~ file ne
 *** Legacy Buttons
 ~legacyButtons~ is used to select the type of buttons. *Default:* ~false~
 *** Hide Cursor
-~hideCusor~ indicates if the cursor is hidden over the game canvas when the game is playing.  *Default:* ~true~
+~hideCusor~ indicates if the cursor is hidden over the game canvas when the game is playing.  *Default:* ~false~
 *** Center
 ~center~ indicates if the game is centred outside of fullscreen mode. *Default:* ~true~
 *** Block Keys
 If ~blockKeys~ is set keys which are used to interact with the game are blocked from scrolling when the game is running.
 
-If un-set keys will only be blocked when the canvas is focused.  *Default:* ~true~
+If un-set keys will only be blocked when the canvas is focused.  *Default:* ~false~
 *** Use Pointer
 
 If ~usePointer~ is set the pointer hand will be used on buttons.
@@ -94,7 +94,7 @@ If un-set a normal cursor will be used on all buttons which do not lead to a new
 
 If ~unpauseOnReset~ is set hitting the reset button when paused will instantly reset the game.
 
-If un-set the game will need to be resumed before it resets. *Default:* ~false~
+If un-set the game will need to be resumed before it resets. *Default:* ~true~
 
 *** Placeholder
 The image to be used as a placeholder prior to starting the game.  If un-set, a black background will be used.  *Default:* ~''~

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-pico-8-demo",
   "homepage": "http://woofers.github.io/react-pico-8",
-  "version": "2.4.3",
+  "version": "3.0.0",
   "dependencies": {
     "@emotion/core": "^10.0.9",
     "@fortawesome/fontawesome-svg-core": "^1.2.17",

--- a/demo/src/app.js
+++ b/demo/src/app.js
@@ -114,12 +114,12 @@ const App = () => {
   ]
   const [autoPlay, setAutoPlay] = useState(true)
   const [legacyButtons, setLegacyButtons] = useState(false)
-  const [hideCursor, setHideCursor] = useState(true)
+  const [hideCursor, setHideCursor] = useState(false)
   const [center, setCenter] = useState(true)
-  const [blockKeys, setBlockKeys] = useState(true)
+  const [blockKeys, setBlockKeys] = useState(false)
   const [isMounted, setMounted] = useState(true)
   const [usePointer, setPointer] = useState(true)
-  const [unpauseOnReset, setUnpauseOnReset] = useState(false)
+  const [unpauseOnReset, setUnpauseOnReset] = useState(true)
   const [buttons, setButtons] = useState(order.map(name => ({
     name,
     Button: picoButtons[name],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pico-8",
-  "version": "2.4.3",
+  "version": "3.0.0",
   "description": "Run PICO-8 game cartridges in React",
   "main": "react-pico-8.js",
   "src": "src/pico-8.js",

--- a/src/pico-8.js
+++ b/src/pico-8.js
@@ -185,11 +185,11 @@ Pico8.defaultProps = {
   autoPlay: true,
   legacyButtons: false,
   placeholder: '',
-  hideCursor: true,
+  hideCursor: false,
   center: false,
-  blockKeys: true,
+  blockKeys: false,
   usePointer: true,
-  unpauseOnReset: false
+  unpauseOnReset: true
 }
 
 export default Pico8


### PR DESCRIPTION
Changes defaults for the following props:

- *hideCursor*: `true` to `false`
- *blockKeys*: `true` to `false`
- *unpauseOnReset*: `false` to `true`

These defaults are a deviation of the original PICO-8 player behaviour however they are more inline with other web games.